### PR TITLE
Support New Zealand invoice format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Default Kimai invoice templates can be found [in the core repository here](https
 
 - [DIN 5008 compliant template](din5008-invoice)
 - [Invoice grouped by projects](grouped-by-projects)
+- [New Zealand invoice templates](nz-pdf)
 
 ### HTML
 

--- a/nz-pdf/README.md
+++ b/nz-pdf/README.md
@@ -1,0 +1,36 @@
+# New Zealand Invoice Templates
+
+PDF invoice templates customized for New Zealand business requirements.
+
+Based on the [default Kimai PDF template](https://github.com/kimai/kimai/blob/main/templates/invoice/renderer/default.pdf.twig).
+
+Includes two variants:
+- `nz-invoice.pdf.twig` - Standard invoice with full item descriptions
+- `nz-invoice-no-desc.pdf.twig` - Simplified invoice showing only project and activity names
+
+## Key Features
+
+- **GST Compliance**: Uses "GST Number" instead of VAT ID throughout the template
+- **NZ Date Format**: Dates displayed in dd MMM yyyy format (e.g., "22 Jan 2026")
+- **Table Dates**: Item dates in ISO format yyyy/MM/dd for clarity
+- **Prominent Payment Section**: Bank account details displayed in a highlighted box below the invoice table with payment reference
+- **Enhanced Readability**: Larger header and footer text (12px) for improved legibility
+
+## Customization
+
+Most values are taken from the Invoice template configuration:
+- `Address` - Company address (header and customer details)
+- `Contact` - Contact information displayed in footer
+- `Payment Details` - Bank account details shown in the payment information box
+- `Payment Terms` - Additional payment terms (supports markdown)
+- `VatID` - Used as GST Number
+- `Title` - Invoice title in header
+
+### Payment Information Section
+
+The template includes a styled payment information box that displays:
+- Bank account details
+- Invoice number as payment reference
+- Optional payment terms
+
+This section appears below the invoice table with a gray background and border for prominence.

--- a/nz-pdf/nz-invoice-no-desc.pdf.twig
+++ b/nz-pdf/nz-invoice-no-desc.pdf.twig
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="{{ invoice['invoice.language'] }}">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}{{ invoice['invoice.number'] }}-{{ invoice['customer.company']|default(invoice['customer.name'])|u.snake }}{% endblock %}</title>
+    <style>
+        {{ encore_entry_css_source('invoice-pdf')|raw }}
+    </style>
+</head>
+<body>
+<!--mpdf
+<htmlpageheader name="header">
+    <table class="header">
+        <tr>
+            <td class="title">
+                {{ invoice['template.title'] }}
+            </td>
+            <td class="date text-right" style="font-size: 14px;">
+                <strong>Date:</strong> {{ invoice['invoice.date']|date('d M Y') }}
+            </td>
+        </tr>
+    </table>
+</htmlpageheader>
+<sethtmlpageheader name="header" page="ALL" value="on" show-this-page="1" />
+<htmlpagefooter name="footer">
+    <table class="footer">
+        <tr>
+            <td style="font-size: 14px;">
+                <strong>{{ 'contact'|trans }}</strong>:
+                {{ invoice['template.contact']|nl2str(' – ') }}
+            </td>
+            <td align="right">
+                {{ 'export.page_of'|trans({'%page%': '{PAGENO}', '%pages%': '{nb}'}) }}
+            </td>
+        </tr>
+    </table>
+</htmlpagefooter>
+<sethtmlpagefooter page="ALL" value="on" name="footer" show-this-page="1" />
+mpdf-->
+    <table class="addresses">
+        <tr>
+            <td style="width:60%">
+                {{ 'invoice.to'|trans }}
+                <br>
+                <strong>{{ invoice['customer.company']|default(invoice['customer.name']) }}</strong>
+                <br>
+                {{ invoice['customer.address']|nl2br }}
+                {% set country = invoice['customer.country']|country_name(invoice['invoice.language']) %}
+                {% if country not in invoice['customer.address'] %}
+                    <br> {{ country }}
+                {% endif %}
+                {% if invoice['customer.vat_id'] is not empty %}
+                    <br>
+                    GST Number: {{ invoice['customer.vat_id'] }}
+                {% endif %}
+            </td>
+            <td>
+                {{ 'invoice.from'|trans }}
+                <br>
+                <strong>{{ invoice['template.company'] }}</strong>
+                <br>
+                {{ invoice['template.address']|trim|nl2br }}
+                {% if invoice['template.country'] is not null %}
+                    {% set country = invoice['template.country']|country_name(invoice['invoice.language']) %}
+                    {% if country not in invoice['template.address'] %}
+                        <br> {{ country }}
+                    {% endif %}
+                {% endif %}
+                {% if invoice['template.vat_id'] is not empty %}
+                    <br>
+                    GST Number:
+                    {{ invoice['template.vat_id'] }}
+                {% endif %}
+            </td>
+        </tr>
+    </table>
+
+    <p>
+        <strong>Invoice Number:</strong>
+        {{ invoice['invoice.number'] }}
+
+        <br>
+        <strong>Invoice Due:</strong>
+        {{ invoice['invoice.due_date']|date('d M Y') }}
+
+        {% if invoice['customer.number'] is not empty %}
+            <br>
+            {{ 'number'|trans }}:
+            {{ invoice['customer.number'] }}
+        {% endif %}
+
+        {% if invoice['query.project.order_number'] is defined and invoice['query.project.order_number'] is not empty %}
+            <br>
+            {{ 'orderNumber'|trans }}:
+            {{ invoice['query.project.order_number'] }}
+        {% endif %}
+    </p>
+
+    {% if invoice['customer.invoice_text'] is not empty%}
+        <p>{{ invoice['customer.invoice_text']|md2html }}</p>
+    {% endif %}
+
+    <table class="items">
+        <thead>
+            <tr>
+                <th class="first"><strong>{{ 'date'|trans }}</strong></th>
+                <th><strong>{{ 'description'|trans }}</strong></th>
+                <th class="text-right"><strong>{{ 'unit_price'|trans }}</strong></th>
+                <th class="text-right"><strong>{{ 'amount'|trans }}</strong></th>
+                <th class="last text-right"><strong>{{ 'total_rate'|trans }}</strong></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for invoiceLineItem in entries %}
+            <!-- CONTENT_PART -->
+            <tr>
+                <td nowrap class="first text-nowrap">{{ invoiceLineItem['entry.begin']|date('Y/m/d') }}</td>
+                <td>
+                    {{ invoiceLineItem['entry.project'] }}
+                    {% if invoiceLineItem['entry.activity'] is defined %}
+                        –
+                        {{ invoiceLineItem['entry.activity'] }}
+                    {% endif %}
+                </td>
+                <td nowrap class="text-nowrap text-right">{{ invoiceLineItem['entry.rate'] }}</td>
+                <td nowrap class="text-nowrap text-right">{{ invoiceLineItem['entry.amount'] }}</td>
+                <td nowrap class="last text-nowrap text-right">{{ invoiceLineItem['entry.total'] }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr>
+                <td colspan="4" class="text-right">
+                    {{ 'invoice.subtotal'|trans }}
+                </td>
+                <td class="last text-right">{{ invoice['invoice.subtotal'] }}</td>
+            </tr>
+            {% for taxRow in invoice['invoice.tax_rows'] %}
+                {% if taxRow['show'] %}
+                <tr>
+                    <td colspan="4" class="text-right">
+                        GST ({{ taxRow['rate'] }}%)
+                        {% if taxRow['note'] is not null %}
+                            <sup>[{{ taxRow['counter'] }}]</sup>
+                        {% endif %}
+                    </td>
+                    <td class="last text-right">{{ taxRow['amount']|money(taxRow['currency']) }}</td>
+                </tr>
+                {% endif %}
+            {% endfor %}
+            <tr>
+                <td colspan="4" class="text-right text-nowrap">
+                    <strong>{{ 'invoice.total'|trans }}</strong>
+                </td>
+                <td class="last text-right">
+                    <strong>{{ invoice['invoice.total'] }}</strong>
+                </td>
+            </tr>
+        </tfoot>
+    </table>
+
+    {% for taxRow in invoice['invoice.tax_rows'] %}
+        {% if taxRow['note'] is not null %}
+            <p>
+                <sup>[{{ taxRow['counter'] }}]</sup>
+                {{ taxRow['note']|trans }}
+            </p>
+        {% endif %}
+    {% endfor %}
+
+    <div style="margin-top: 30px; padding: 15px; border: 1px solid #ccc; background-color: #f9f9f9;">
+        <h3 style="margin-top: 0; margin-bottom: 10px; font-size: 16px;">Payment Information</h3>
+
+        <strong>Bank Details:</strong>
+        {{ invoice['template.payment_details']|nl2br }}
+        <br>
+
+        <strong>Reference:</strong>
+        {{ invoice['invoice.number'] }}
+        <br>
+        <br>
+
+        {% if invoice['template.payment_terms'] is not empty %}
+            {{ invoice['template.payment_terms']|md2html }}
+        {% endif %}
+    </div>
+</body>
+</html>

--- a/nz-pdf/nz-invoice.pdf.twig
+++ b/nz-pdf/nz-invoice.pdf.twig
@@ -15,8 +15,8 @@
             <td class="title">
                 {{ invoice['template.title'] }}
             </td>
-            <td class="date text-right">
-                {{ 'date'|trans }}: {{ invoice['invoice.date'] }}
+            <td class="date text-right" style="font-size: 14px;">
+                <strong>Date:</strong> {{ invoice['invoice.date']|date('d M Y') }}
             </td>
         </tr>
     </table>
@@ -25,12 +25,9 @@
 <htmlpagefooter name="footer">
     <table class="footer">
         <tr>
-            <td>
+            <td style="font-size: 14px;">
                 <strong>{{ 'contact'|trans }}</strong>:
                 {{ invoice['template.contact']|nl2str(' – ') }}
-                <br>
-                <strong>{{ 'invoice_bank_account'|trans }}</strong>:
-                {{ invoice['template.payment_details']|nl2str(' – ') }}
             </td>
             <td align="right">
                 {{ 'export.page_of'|trans({'%page%': '{PAGENO}', '%pages%': '{nb}'}) }}
@@ -54,7 +51,7 @@ mpdf-->
                 {% endif %}
                 {% if invoice['customer.vat_id'] is not empty %}
                     <br>
-                    {{ 'vat_id'|trans }}: {{ invoice['customer.vat_id'] }}
+                    GST Number: {{ invoice['customer.vat_id'] }}
                 {% endif %}
             </td>
             <td>
@@ -71,7 +68,7 @@ mpdf-->
                 {% endif %}
                 {% if invoice['template.vat_id'] is not empty %}
                     <br>
-                    {{ 'vat_id'|trans }}:
+                    GST Number:
                     {{ invoice['template.vat_id'] }}
                 {% endif %}
             </td>
@@ -79,12 +76,12 @@ mpdf-->
     </table>
 
     <p>
-        {{ 'invoice.number'|trans }}:
+        <strong>Invoice Number:</strong>
         {{ invoice['invoice.number'] }}
 
         <br>
-        {{ 'invoice.due_days'|trans }}:
-        {{ invoice['invoice.due_date'] }}
+        <strong>Invoice Due:</strong>
+        {{ invoice['invoice.due_date']|date('d M Y') }}
 
         {% if invoice['customer.number'] is not empty %}
             <br>
@@ -117,7 +114,7 @@ mpdf-->
         {% for invoiceLineItem in entries %}
             <!-- CONTENT_PART -->
             <tr>
-                <td nowrap class="first text-nowrap">{{ invoiceLineItem['entry.begin'] }}</td>
+                <td nowrap class="first text-nowrap">{{ invoiceLineItem['entry.begin']|date('Y/m/d') }}</td>
                 <td>
                     {% if invoiceLineItem['entry.description'] is not empty %}
                         {{ invoiceLineItem['entry.description']|nl2br }}
@@ -145,7 +142,7 @@ mpdf-->
                 {% if taxRow['show'] %}
                 <tr>
                     <td colspan="4" class="text-right">
-                        {{ taxRow['name']|trans }} ({{ taxRow['rate'] }}%)
+                        GST ({{ taxRow['rate'] }}%)
                         {% if taxRow['note'] is not null %}
                             <sup>[{{ taxRow['counter'] }}]</sup>
                         {% endif %}
@@ -174,8 +171,21 @@ mpdf-->
         {% endif %}
     {% endfor %}
 
-    {% if invoice['template.payment_terms'] is not empty %}
-        {{ invoice['template.payment_terms']|md2html }}
-    {% endif %}
+    <div style="margin-top: 30px; padding: 15px; border: 1px solid #ccc; background-color: #f9f9f9;">
+        <h3 style="margin-top: 0; margin-bottom: 10px; font-size: 16px;">Payment Information</h3>
+
+        <strong>Bank Details:</strong>
+        {{ invoice['template.payment_details']|nl2br }}
+        <br>
+
+        <strong>Reference:</strong>
+        {{ invoice['invoice.number'] }}
+        <br>
+        <br>
+
+        {% if invoice['template.payment_terms'] is not empty %}
+            {{ invoice['template.payment_terms']|md2html }}
+        {% endif %}
+    </div>
 </body>
 </html>

--- a/nz-pdf/nz_invoice.pdf.twig
+++ b/nz-pdf/nz_invoice.pdf.twig
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="{{ invoice['invoice.language'] }}">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}{{ invoice['invoice.number'] }}-{{ invoice['customer.company']|default(invoice['customer.name'])|u.snake }}{% endblock %}</title>
+    <style>
+        {{ encore_entry_css_source('invoice-pdf')|raw }}
+    </style>
+</head>
+<body>
+<!--mpdf
+<htmlpageheader name="header">
+    <table class="header">
+        <tr>
+            <td class="title">
+                {{ invoice['template.title'] }}
+            </td>
+            <td class="date text-right">
+                {{ 'date'|trans }}: {{ invoice['invoice.date'] }}
+            </td>
+        </tr>
+    </table>
+</htmlpageheader>
+<sethtmlpageheader name="header" page="ALL" value="on" show-this-page="1" />
+<htmlpagefooter name="footer">
+    <table class="footer">
+        <tr>
+            <td>
+                <strong>{{ 'contact'|trans }}</strong>:
+                {{ invoice['template.contact']|nl2str(' – ') }}
+                <br>
+                <strong>{{ 'invoice_bank_account'|trans }}</strong>:
+                {{ invoice['template.payment_details']|nl2str(' – ') }}
+            </td>
+            <td align="right">
+                {{ 'export.page_of'|trans({'%page%': '{PAGENO}', '%pages%': '{nb}'}) }}
+            </td>
+        </tr>
+    </table>
+</htmlpagefooter>
+<sethtmlpagefooter page="ALL" value="on" name="footer" show-this-page="1" />
+mpdf-->
+    <table class="addresses">
+        <tr>
+            <td style="width:60%">
+                {{ 'invoice.to'|trans }}
+                <br>
+                <strong>{{ invoice['customer.company']|default(invoice['customer.name']) }}</strong>
+                <br>
+                {{ invoice['customer.address']|nl2br }}
+                {% set country = invoice['customer.country']|country_name(invoice['invoice.language']) %}
+                {% if country not in invoice['customer.address'] %}
+                    <br> {{ country }}
+                {% endif %}
+                {% if invoice['customer.vat_id'] is not empty %}
+                    <br>
+                    {{ 'vat_id'|trans }}: {{ invoice['customer.vat_id'] }}
+                {% endif %}
+            </td>
+            <td>
+                {{ 'invoice.from'|trans }}
+                <br>
+                <strong>{{ invoice['template.company'] }}</strong>
+                <br>
+                {{ invoice['template.address']|trim|nl2br }}
+                {% if invoice['template.country'] is not null %}
+                    {% set country = invoice['template.country']|country_name(invoice['invoice.language']) %}
+                    {% if country not in invoice['template.address'] %}
+                        <br> {{ country }}
+                    {% endif %}
+                {% endif %}
+                {% if invoice['template.vat_id'] is not empty %}
+                    <br>
+                    {{ 'vat_id'|trans }}:
+                    {{ invoice['template.vat_id'] }}
+                {% endif %}
+            </td>
+        </tr>
+    </table>
+
+    <p>
+        {{ 'invoice.number'|trans }}:
+        {{ invoice['invoice.number'] }}
+
+        <br>
+        {{ 'invoice.due_days'|trans }}:
+        {{ invoice['invoice.due_date'] }}
+
+        {% if invoice['customer.number'] is not empty %}
+            <br>
+            {{ 'number'|trans }}:
+            {{ invoice['customer.number'] }}
+        {% endif %}
+
+        {% if invoice['query.project.order_number'] is defined and invoice['query.project.order_number'] is not empty %}
+            <br>
+            {{ 'orderNumber'|trans }}:
+            {{ invoice['query.project.order_number'] }}
+        {% endif %}
+    </p>
+
+    {% if invoice['customer.invoice_text'] is not empty%}
+        <p>{{ invoice['customer.invoice_text']|md2html }}</p>
+    {% endif %}
+
+    <table class="items">
+        <thead>
+            <tr>
+                <th class="first"><strong>{{ 'date'|trans }}</strong></th>
+                <th><strong>{{ 'description'|trans }}</strong></th>
+                <th class="text-right"><strong>{{ 'unit_price'|trans }}</strong></th>
+                <th class="text-right"><strong>{{ 'amount'|trans }}</strong></th>
+                <th class="last text-right"><strong>{{ 'total_rate'|trans }}</strong></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for invoiceLineItem in entries %}
+            <!-- CONTENT_PART -->
+            <tr>
+                <td nowrap class="first text-nowrap">{{ invoiceLineItem['entry.begin'] }}</td>
+                <td>
+                    {% if invoiceLineItem['entry.description'] is not empty %}
+                        {{ invoiceLineItem['entry.description']|nl2br }}
+                    {% else %}
+                        {% if invoiceLineItem['entry.activity'] is defined %}
+                            {{ invoiceLineItem['entry.activity'] }} /
+                        {% endif %}
+                        {{ invoiceLineItem['entry.project'] }}
+                    {% endif %}
+                </td>
+                <td nowrap class="text-nowrap text-right">{{ invoiceLineItem['entry.rate'] }}</td>
+                <td nowrap class="text-nowrap text-right">{{ invoiceLineItem['entry.amount'] }}</td>
+                <td nowrap class="last text-nowrap text-right">{{ invoiceLineItem['entry.total'] }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr>
+                <td colspan="4" class="text-right">
+                    {{ 'invoice.subtotal'|trans }}
+                </td>
+                <td class="last text-right">{{ invoice['invoice.subtotal'] }}</td>
+            </tr>
+            {% for taxRow in invoice['invoice.tax_rows'] %}
+                {% if taxRow['show'] %}
+                <tr>
+                    <td colspan="4" class="text-right">
+                        {{ taxRow['name']|trans }} ({{ taxRow['rate'] }}%)
+                        {% if taxRow['note'] is not null %}
+                            <sup>[{{ taxRow['counter'] }}]</sup>
+                        {% endif %}
+                    </td>
+                    <td class="last text-right">{{ taxRow['amount']|money(taxRow['currency']) }}</td>
+                </tr>
+                {% endif %}
+            {% endfor %}
+            <tr>
+                <td colspan="4" class="text-right text-nowrap">
+                    <strong>{{ 'invoice.total'|trans }}</strong>
+                </td>
+                <td class="last text-right">
+                    <strong>{{ invoice['invoice.total'] }}</strong>
+                </td>
+            </tr>
+        </tfoot>
+    </table>
+
+    {% for taxRow in invoice['invoice.tax_rows'] %}
+        {% if taxRow['note'] is not null %}
+            <p>
+                <sup>[{{ taxRow['counter'] }}]</sup>
+                {{ taxRow['note']|trans }}
+            </p>
+        {% endif %}
+    {% endfor %}
+
+    {% if invoice['template.payment_terms'] is not empty %}
+        {{ invoice['template.payment_terms']|md2html }}
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
PDF invoice templates customized for New Zealand business requirements (eg GST)

Based on the [default Kimai PDF template](https://github.com/kimai/kimai/blob/main/templates/invoice/renderer/default.pdf.twig).