### PR TITLE
Fix grouped-by-projects date rendering with localized invoice dates

### DIFF
--- a/grouped-by-projects/grouped-by-projects.pdf.twig
+++ b/grouped-by-projects/grouped-by-projects.pdf.twig
@@ -4,7 +4,7 @@
 {%- set logoUrl = config('theme.branding.logo') -%}
 {%- set groupByMaxProjects = 50 -%}
 {# End Configuration #}
-{%- set filename = invoice['invoice.date']|date('Y-m-d') ~ '_' ~ invoice['invoice.number']|replace({'/' : '-'}) ~ '_' ~ invoice['customer.company']|default(invoice['customer.name'])|replace({' ' : '-'}) -%}
+{%- set filename = model.invoiceDate|date('Y-m-d') ~ '_' ~ invoice['invoice.number']|replace({'/' : '-'}) ~ '_' ~ invoice['customer.company']|default(invoice['customer.name'])|replace({' ' : '-'}) -%}
 {%- set option = pdfContext.setOption('filename', filename) -%}
 {%- set option = pdfContext.setOption('format', 'A4-P') -%}
 {%- set setAutoTopMargin = pdfContext.setOption('setAutoTopMargin', false) -%}
@@ -17,7 +17,7 @@
 <html lang="{{ invoice['invoice.language'] }}">
 <head>
     <meta charset="UTF-8">
-    <title>{% block title %}{{ invoice['invoice.date']|date('Y-m-d') }} {{ invoice['invoice.number'] }} {{ invoice['customer.company']|default(invoice['customer.name']) }}{% endblock %}</title>
+    <title>{% block title %}{{ model.invoiceDate|date('Y-m-d') }} {{ invoice['invoice.number'] }} {{ invoice['customer.company']|default(invoice['customer.name']) }}{% endblock %}</title>
 
     {% block invoice_styles %}
         <style type="text/css">

--- a/grouped-by-projects/grouped-by-projects.pdf.twig
+++ b/grouped-by-projects/grouped-by-projects.pdf.twig
@@ -4,7 +4,7 @@
 {%- set logoUrl = config('theme.branding.logo') -%}
 {%- set groupByMaxProjects = 50 -%}
 {# End Configuration #}
-{%- set filename = model.invoiceDate|date('Y-m-d') ~ '_' ~ invoice['invoice.number']|replace({'/' : '-'}) ~ '_' ~ invoice['customer.company']|default(invoice['customer.name'])|replace({' ' : '-'}) -%}
+{%- set filename = invoice['invoice.date_process']|date('Y-m-d') ~ '_' ~ invoice['invoice.number']|replace({'/' : '-'}) ~ '_' ~ invoice['customer.company']|default(invoice['customer.name'])|replace({' ' : '-'}) -%}
 {%- set option = pdfContext.setOption('filename', filename) -%}
 {%- set option = pdfContext.setOption('format', 'A4-P') -%}
 {%- set setAutoTopMargin = pdfContext.setOption('setAutoTopMargin', false) -%}
@@ -17,7 +17,7 @@
 <html lang="{{ invoice['invoice.language'] }}">
 <head>
     <meta charset="UTF-8">
-    <title>{% block title %}{{ model.invoiceDate|date('Y-m-d') }} {{ invoice['invoice.number'] }} {{ invoice['customer.company']|default(invoice['customer.name']) }}{% endblock %}</title>
+    <title>{% block title %}{{ invoice['invoice.date_process']|date('Y-m-d') }} {{ invoice['invoice.number'] }} {{ invoice['customer.company']|default(invoice['customer.name']) }}{% endblock %}</title>
 
     {% block invoice_styles %}
         <style type="text/css">

--- a/grouped-by-projects/grouped-by-projects.pdf.twig
+++ b/grouped-by-projects/grouped-by-projects.pdf.twig
@@ -483,7 +483,7 @@ mpdf-->
 
                         <tr>
                             <td></td>
-                            <td class="project-total t-left">Zwischensumme:</td>
+                            <td class="project-total t-left">{{ 'invoice.subtotal'|trans }}:</td>
                             <td class="project-total t-nowrap t-center">{{ totalDuration|duration }}</td>
                             <td></td>
                             <td class="project-total t-nowrap t-right">{{ totalAmount|money(invoice['invoice.currency']) }}</td>


### PR DESCRIPTION
## Summary

Fixes `grouped-by-projects.pdf.twig` when Kimai provides localized invoice date strings such as `16/1/24` or `28/5/2026`.

The template was applying Twig's `date` filter to `invoice['invoice.date']`, which can already be a localized display string and may fail PHP date parsing depending on locale. This PR uses `model.invoiceDate` instead, matching the DateTime object available in the invoice model.

Also replaces a hard-coded German `Zwischensumme:` label with Kimai's translated `invoice.subtotal` string.

## Changes

- Use `model.invoiceDate|date('Y-m-d')` for the generated PDF filename.
- Use `model.invoiceDate|date('Y-m-d')` for the HTML title.
- Replace hard-coded subtotal text with `{{ 'invoice.subtotal'|trans }}`.

## Fixes

Fixes #15.